### PR TITLE
Wait for DB service before starting AIDA

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,10 @@ services:
     ports:
       - 4000:4000
     depends_on:
-      - db
+      pspdfkit:
+        condition: service_started
+      db:
+        condition: service_healthy
 
   pspdfkit:
     image: pspdfkit/document-engine:nightly
@@ -62,6 +65,11 @@ services:
       - db
   db:
     image: pgvector/pgvector:pg16
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U db-user" ]
+      interval: 3s
+      timeout: 3s
+      retries: 10
     environment:
       POSTGRES_USER: db-user
       POSTGRES_PASSWORD: password


### PR DESCRIPTION
AIDA checks for the existence of the DB when starting up. If it does not exist, it'll exit. Therefore, we have to wait until the DB is ready (which can take a few seconds due to postgres bring up time). 