### PR TITLE
Remove unused users route from frontend

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5,7 +5,6 @@ var cookieParser = require('cookie-parser');
 var logger = require('morgan');
 
 var indexRouter = require('./routes/index');
-var usersRouter = require('./routes/users');
 var documentsRouter = require("./routes/documents")
 
 var app = express();
@@ -21,7 +20,6 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
-app.use('/users', usersRouter);
 app.use("/documents", documentsRouter);
 
 // catch 404 and forward to error handler

--- a/frontend/routes/users.js
+++ b/frontend/routes/users.js
@@ -1,9 +1,0 @@
-var express = require('express');
-var router = express.Router();
-
-/* GET users listing. */
-router.get('/', function(req, res, next) {
-  res.send('respond with a resource');
-});
-
-module.exports = router;


### PR DESCRIPTION
I don't see `users` route being used. And I can't see where it would be required. Removing 