### PR TITLE
Remove defaulted environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       DE_API_AUTH_TOKEN: secret
       PGUSER: db-user
       PGPASSWORD: password
-      PGDATABASE: document_assistant
+      PGDATABASE: ai_document_assistant
       PGHOST: db
       PGPORT: 5432
       API_AUTH_TOKEN: secret
@@ -63,7 +63,7 @@ services:
     environment:
       POSTGRES_USER: db-user
       POSTGRES_PASSWORD: password
-      POSTGRES_DB: ai-document-assistant
+      POSTGRES_DB: ai_document_assistant
       POSTGRES_INITDB_ARGS: --data-checksums
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:


### PR DESCRIPTION
PGSSL: is defaulted to false, thus it's not required. Although I do see why it's useful to explicitly add, we could argue that this should never be defaulted and should be a hard fail. I just took the same design from Document Engine. 

SECRET_KEY_BASE: Is not a variable used in AIDA.

`POSTGRES_DB: ai_document_assistant` aligns default DB naming