### PR TITLE
Improve PSPDFKit Web view

### DIFF
--- a/frontend/public/style.css
+++ b/frontend/public/style.css
@@ -1,6 +1,11 @@
 body {
-  padding: 50px;
+  margin: 0;
+  padding: 0;
   font: 14px "Lucida Grande", Helvetica, Arial, sans-serif;
+}
+
+header {
+  display: none;
 }
 
 a {

--- a/frontend/views/documents/show.ejs
+++ b/frontend/views/documents/show.ejs
@@ -1,27 +1,36 @@
-<script src="https://cdn.cloud.staging.pspdfkit.com/pspdfkit-web@2024.5.2-d54c4ac/pspdfkit.js"></script>
-<!-- 2. Element where PSPDFKit will be mounted. -->
-<div id="pspdfkit" style="width: 100vw; height: 100vh;"></div>
-<!-- 3. Initialize PSPDFKit. -->
-<script>
-  console.log("Show document <%= documentId %>");
-  console.log("JWT <%= jwt %>");
-  PSPDFKit.load({
-    serverUrl: "http://localhost:5000/",
-    container: "#pspdfkit",
-    documentId: "<%= documentId %>",
-    authPayload: { jwt: "<%= jwt %>" },
-    instant: false,
-    toolbarItems: [...PSPDFKit.defaultToolbarItems, { type: "ai-document-assistant" }],
-    aiDocumentAssistant: {
-      sessionId: "my-random-session-id",
-      jwt: "<%= aiJwt %>",
-      backendUrl: 'http://localhost:4000/',
-    },
-  })
-    .then(function(instance) {
-      console.log("PSPDFKit loaded", instance);
-    })
-    .catch(function(error) {
-      console.error(error.message);
-    });
-</script>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script src="https://cdn.cloud.staging.pspdfkit.com/pspdfkit-web@2024.5.2-d54c4ac/pspdfkit.js"></script>
+    <title>AI Document Assistant Example App</title>
+    <link rel='stylesheet' href='/style.css' />
+</head>
+<body class="container">
+    <!-- Element where PSPDFKit will be mounted. -->
+    <div id="pspdfkit" style="width: 100vw; height: 100vh"></div>
+    <!-- Initialize PSPDFKit. -->
+    <script>
+        console.log("Show document <%= documentId %>");
+        console.log("JWT <%= jwt %>");
+        PSPDFKit.load({
+            serverUrl: "http://localhost:5000/",
+            container: "#pspdfkit",
+            documentId: "<%= documentId %>",
+            authPayload: { jwt: "<%= jwt %>" },
+            instant: false,
+            toolbarItems: [...PSPDFKit.defaultToolbarItems, { type: "ai-document-assistant" }],
+            aiDocumentAssistant: {
+                sessionId: "my-random-session-id",
+                jwt: "<%= aiJwt %>",
+                backendUrl: 'http://localhost:4000/',
+            },
+        })
+            .then(function(instance) {
+                console.log("PSPDFKit loaded", instance);
+            })
+            .catch(function(error) {
+                console.error(error.message);
+            });
+    </script>
+</body>
+

--- a/frontend/views/index.ejs
+++ b/frontend/views/index.ejs
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title><%= title %></title>
-    <link rel='stylesheet' href='/stylesheets/style.css' />
+    <link rel='stylesheet' href='/style.css' />
   </head>
   <body>
     <h1><%= title %></h1>


### PR DESCRIPTION
- Use stylesheet to remove margins from the document view so PSPDFKit for Web is full screen
- statically served public folder was no recursive. To get round this I just moved `style.css` to the root of `static. 

The only part I could get rid of was the small scroll bars. Not sure why, didn't have time to dig further. 

With this PR we get the following result. 
![Screenshot 2024-09-23 at 2 46 31 PM](https://github.com/user-attachments/assets/491377a3-a235-4046-b154-a54b698579fe)
