### PR TITLE
Bump to pspdfkit/ai-assistant to 1.1.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   ai-assistant:
-    image: pspdfkit/ai-document-assistant:1.0.0
+    image: pspdfkit/ai-assistant:1.1.0
     environment:
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       DE_URL: http://document-engine:5000
@@ -26,6 +26,7 @@ services:
       JWT_ALGORITHM: RS256
       DASHBOARD_USERNAME: dashboard
       DASHBOARD_PASSWORD: secret
+      SECRET_KEY_BASE: secret
     ports:
       - 4000:4000
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       JWT_ALGORITHM: RS256
       DASHBOARD_USERNAME: dashboard
       DASHBOARD_PASSWORD: secret
-      SECRET_KEY_BASE: secret
+      SECRET_KEY_BASE: secret-key-base
     ports:
       - 4000:4000
     depends_on:


### PR DESCRIPTION
This PR updates the example to use the newly release Nutrient AI Assistant 1.1.0. 

In this release, there was a new required environment variables of `SECRET_KEY_BASE`, which has also been added.