### PR TITLE
Renaming AI Assistant code references for Nutrient Web SDK 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ When the AI Assistant is ready to use, you will see `info: AI Assistant started 
 
 Head over to URL listed on the command line, where you'll see a PDF loaded in PSPDFKit for Web, our document viewer. Click on the AI Assistant toolbar icon (star) to start interacting with your document in an entirely new way, using natural language commands.
 
-![Screenshot-of-PSPDFKit-AI-Document-Assistant](assets/AI-Assistant-overview.png)
+![Screenshot-of-PSPDFKit-AI-Assistant](assets/AI-Assistant-overview.png)
 
 ## Contact Us
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       DE_API_AUTH_TOKEN: secret
       PGUSER: db-user
       PGPASSWORD: password
-      PGDATABASE: ai_document_assistant
+      PGDATABASE: ai_assistant
       PGHOST: db
       PGPORT: 5432
       API_AUTH_TOKEN: secret
@@ -65,14 +65,14 @@ services:
   db:
     image: pgvector/pgvector:pg16
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U db-user -d ai_document_assistant" ]
+      test: [ "CMD-SHELL", "pg_isready -U db-user -d ai_assistant" ]
       interval: 3s
       timeout: 3s
       retries: 10
     environment:
       POSTGRES_USER: db-user
       POSTGRES_PASSWORD: password
-      POSTGRES_DB: ai_document_assistant
+      POSTGRES_DB: ai_assistant
       POSTGRES_INITDB_ARGS: --data-checksums
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:

--- a/frontend/routes/documents.js
+++ b/frontend/routes/documents.js
@@ -7,7 +7,7 @@ var jwtKey = fs.readFileSync(path.resolve(__dirname, '../config/pspdfkit/jwt.pem
 
 router.get('/:documentId', function (req, res, next) {
   var jwt = prepareJwt(req.params.documentId)
-  var aiJwt = prepareAIDocumentAssistantJwt(req.params.documentId)
+  var aiJwt = prepareAIAssistantJwt(req.params.documentId)
   res.render('documents/show', { documentId: req.params.documentId, jwt: jwt, aiJwt: aiJwt })
 })
 
@@ -24,7 +24,7 @@ var prepareJwt = function (documentId) {
   })
 }
 
-const prepareAIDocumentAssistantJwt = function (documentId) {
+const prepareAIAssistantJwt = function (documentId) {
   var claims = {
     document_ids: [documentId],
   }

--- a/frontend/views/documents/show.ejs
+++ b/frontend/views/documents/show.ejs
@@ -19,7 +19,7 @@
             authPayload: { jwt: "<%= jwt %>" },
             instant: false,
             toolbarItems: [...PSPDFKit.defaultToolbarItems, { type: "ai-assistant" }],
-            aiDocumentAssistant: {
+            aiAssistant: {
                 sessionId: "my-random-session-id",
                 jwt: "<%= aiJwt %>",
                 backendUrl: 'http://localhost:4000/',

--- a/frontend/views/documents/show.ejs
+++ b/frontend/views/documents/show.ejs
@@ -18,7 +18,7 @@
             documentId: "<%= documentId %>",
             authPayload: { jwt: "<%= jwt %>" },
             instant: false,
-            toolbarItems: [...PSPDFKit.defaultToolbarItems, { type: "ai-document-assistant" }],
+            toolbarItems: [...PSPDFKit.defaultToolbarItems, { type: "ai-assistant" }],
             aiDocumentAssistant: {
                 sessionId: "my-random-session-id",
                 jwt: "<%= aiJwt %>",

--- a/frontend/views/documents/show.ejs
+++ b/frontend/views/documents/show.ejs
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@2024.6.0/pspdfkit.js"></script>
+    <script src="https://cdn.cloud.pspdfkit.com/pspdfkit-web@2024.8.1/pspdfkit.js"></script>
     <title>AI Assistant Example App</title>
     <link rel='stylesheet' href='/style.css' />
 </head>


### PR DESCRIPTION
Public naming of all configurations and functions was changed in 2024.8.1 to AI assistant. 
This includes 
- `aiAssistant` configuration
- `showAIAssisant` function
- `ai-assistant` toolbar item. 

In addition to these naming changes, I updated local functions to reflect the naming change. 