### PR TITLE
Add framework quickstart examples for AI assistant demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ Head over to URL listed on the command line, where you'll see a PDF loaded in th
 
 ![Screenshot-of-Nutrient-AI-Assistant](assets/AI-Assistant-overview.png)
 
+## Framework Quickstarts
+
+Framework-oriented examples are available in [`framework-examples/`](./framework-examples/README.md):
+
+- [OpenAI Agents quickstart](./framework-examples/openai-agents.mjs)
+- [LangChain quickstart](./framework-examples/langchain.mjs)
+- [CrewAI quickstart](./framework-examples/crewai.py)
+
+Syntax-check commands:
+
+```shell
+node --check framework-examples/openai-agents.mjs
+node --check framework-examples/langchain.mjs
+python3 -m py_compile framework-examples/crewai.py
+```
+
 ## Contact Us
 
 Excited about the possibilities of this new technology? [Contact us](https://www.nutrient.io/contact-sales) to discuss how you can integrate it into your workflows and purchase a license after evaluation.

--- a/framework-examples/README.md
+++ b/framework-examples/README.md
@@ -1,0 +1,26 @@
+# AI Assistant Framework Quickstarts
+
+These examples show how to pair the demo stack with common agent frameworks.
+
+## Files
+
+- `openai-agents.mjs` - OpenAI Agents SDK quickstart calling a document-processing helper.
+- `langchain.mjs` - LangChain tool-calling quickstart for document operations.
+- `crewai.py` - CrewAI quickstart with a simple task pipeline for document prep and review.
+
+## Validation
+
+Use syntax checks before adapting these snippets:
+
+```bash
+node --check openai-agents.mjs
+node --check langchain.mjs
+python3 -m py_compile crewai.py
+```
+
+## Environment
+
+- `OPENAI_API_KEY` for OpenAI-based examples.
+- `NUTRIENT_API_KEY` for document-processing requests.
+
+Snippets are intentionally minimal and should be adapted to your production auth, storage, and sandbox setup.

--- a/framework-examples/crewai.py
+++ b/framework-examples/crewai.py
@@ -1,0 +1,45 @@
+import os
+
+from crewai import Agent, Crew, Task
+
+
+api_key = os.getenv("NUTRIENT_API_KEY", "nutr_sk_placeholder")
+
+
+document_operator = Agent(
+    role="Document Operations Specialist",
+    goal="Plan robust document processing runs for AI assistant workflows.",
+    backstory="You specialize in OCR, extraction, and redaction pipelines."
+)
+
+qa_reviewer = Agent(
+    role="Quality Reviewer",
+    goal="Validate that document output requirements are met.",
+    backstory="You catch processing and compliance gaps before release."
+)
+
+plan_task = Task(
+    description=(
+        "Given api key availability, plan an OCR + redact pipeline "
+        "for incoming onboarding forms."
+    ),
+    expected_output="Step-by-step processing plan with checkpoints.",
+    agent=document_operator
+)
+
+review_task = Task(
+    description="Review the pipeline plan and list risks and mitigations.",
+    expected_output="Risk checklist with remediation actions.",
+    agent=qa_reviewer
+)
+
+crew = Crew(
+    agents=[document_operator, qa_reviewer],
+    tasks=[plan_task, review_task],
+    verbose=True
+)
+
+
+if __name__ == "__main__":
+    print(f"NUTRIENT_API_KEY configured: {api_key != 'nutr_sk_placeholder'}")
+    print(crew.kickoff())

--- a/framework-examples/langchain.mjs
+++ b/framework-examples/langchain.mjs
@@ -1,0 +1,48 @@
+import { ChatOpenAI } from "@langchain/openai";
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+const processDocumentTool = tool(
+  async ({ inputPath, operation }) => {
+    return {
+      status: "queued",
+      inputPath,
+      operation,
+      nextStep: "Call your Nutrient endpoint or MCP server with this payload."
+    };
+  },
+  {
+    name: "process_document",
+    description: "Prepare a document-processing request for Nutrient workflows.",
+    schema: z.object({
+      inputPath: z.string(),
+      operation: z.enum(["ocr", "extract_text", "redact", "convert"])
+    })
+  }
+);
+
+async function main() {
+  const model = new ChatOpenAI({
+    apiKey: process.env.OPENAI_API_KEY,
+    model: "gpt-4.1-mini"
+  }).bindTools([processDocumentTool]);
+
+  const response = await model.invoke(
+    "Queue OCR for ./assets/invoice-scan.pdf and explain what happens next."
+  );
+
+  const toolCalls = response.tool_calls ?? response.toolCalls ?? [];
+  if (toolCalls.length > 0) {
+    for (const call of toolCalls) {
+      if (call.name !== "process_document") continue;
+      const args = typeof call.args === "string" ? JSON.parse(call.args) : call.args;
+      const toolResult = await processDocumentTool.invoke(args);
+      console.log("Tool result:", toolResult);
+    }
+    return;
+  }
+
+  console.log(response.content);
+}
+
+void main();

--- a/framework-examples/openai-agents.mjs
+++ b/framework-examples/openai-agents.mjs
@@ -1,0 +1,35 @@
+import fs from "node:fs/promises";
+import OpenAI from "openai";
+import { Agent, Runner, functionTool } from "@openai/agents";
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+const summarizeDocument = functionTool({
+  name: "summarize_document",
+  description: "Summarize a local document before handing it to the AI assistant.",
+  parameters: {
+    type: "object",
+    properties: {
+      path: { type: "string" }
+    },
+    required: ["path"]
+  },
+  async execute({ path }) {
+    const content = await fs.readFile(path, "utf8");
+    return content.slice(0, 2500);
+  }
+});
+
+const assistant = new Agent({
+  name: "nutrient-ai-assistant",
+  instructions:
+    "You help users review document content and plan the next processing step.",
+  tools: [summarizeDocument]
+});
+
+async function main() {
+  const result = await Runner.run(assistant, "Summarize README.md.");
+  console.log(result.finalOutput);
+}
+
+void main();


### PR DESCRIPTION
## Summary
- add a `Framework Quickstarts` section in the root README
- add runnable integration sketches under `framework-examples/` for:
  - OpenAI Agents (`openai-agents.mjs`)
  - LangChain (`langchain.mjs`)
  - CrewAI (`crewai.py`)
- include explicit syntax-check commands in `framework-examples/README.md`

## Validation
- `node --check framework-examples/openai-agents.mjs`
- `node --check framework-examples/langchain.mjs`
- `python3 -m py_compile framework-examples/crewai.py`
- `codex review --disable apps -c model_reasoning_effort='"low"' --uncommitted`
