### PR TITLE
Update AI Assistant demo to 2.3.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   ai-assistant:
-    image: pspdfkit/ai-assistant:2.2.0
+    image: pspdfkit/ai-assistant:2.3.0
     environment:
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       PGUSER: db-user

--- a/document-engine/docker-compose.yml
+++ b/document-engine/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   ai-assistant:
-    image: pspdfkit/ai-assistant:2.2.0
+    image: pspdfkit/ai-assistant:2.3.0
     environment:
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       DE_URL: http://pspdfkit:5000


### PR DESCRIPTION
## Why
Update AI Assistant to version 2.3.0.

## Verification
- Generated from the release demo snapshot.